### PR TITLE
Because we have an async rendering there is a second where winit laun…

### DIFF
--- a/crates/egor_app/src/lib.rs
+++ b/crates/egor_app/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod input;
 pub mod time;
 
+use crate::{input::Input, time::FrameTimer};
 use std::sync::Arc;
-
 pub use winit::{event::WindowEvent, window::Window};
 
 use winit::{
@@ -10,8 +10,6 @@ use winit::{
     event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy},
     window::WindowId,
 };
-
-use crate::{input::Input, time::FrameTimer};
 
 pub struct AppConfig {
     pub title: String,
@@ -86,6 +84,11 @@ impl<R, H: AppHandler<R> + 'static> ApplicationHandler<(R, H)> for AppRunner<R, 
                     attrs = attrs.with_append(true);
                 }
 
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    attrs = attrs.with_visible(false);
+                }
+
                 attrs
             };
             let window = Arc::new(event_loop.create_window(win_attrs).unwrap());
@@ -151,6 +154,10 @@ impl<R, H: AppHandler<R> + 'static> ApplicationHandler<(R, H)> for AppRunner<R, 
 
         if let (Some(r), Some(h), Some(w)) = (&mut self.resource, &mut self.handler, &self.window) {
             h.on_ready(w, r);
+
+            // Show window after renderer is ready to prevent white flash
+            #[cfg(not(target_arch = "wasm32"))]
+            w.set_visible(true);
         }
     }
 }


### PR DESCRIPTION
…ches without anything draw.

This makes it so winnit isn't visible until we are ready for it.

## Checklist

- [ ✅ ] Read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ✅  ] PR addresses **one issue or feature**
- [ ✅ ] Commits are clean and logically separated
- [ ✅ ] Code builds on native **and** wasm (if applicable)
- [ ✅ ] Pre-PR checklist completed (check contributing)
