### PR TITLE
fix(android): adjust leftover mention of egor::main attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Make sure your crate is a library:
 crate-type = ["cdylib", "rlib"]
 ```
 
-Have a lib.rs with your #[egor::main] function:
+Have a lib.rs with your `egor::main` function:
 
 ```rust
-#[egor::main]
+egor::main!(main);
 fn main() {
     App::new().run()
 }


### PR DESCRIPTION
Didn't check documentation 💀 

## Checklist

- [x] Read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] PR addresses **one issue or feature**
- [x] Commits are clean and logically separated
- [x] Code builds on native **and** wasm
- [x] Pre-PR checklist completed (check contributing)