### PR TITLE
Added touch input and multi touch support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "demo_egor_multi_touch"
+version = "0.0.0"
+dependencies = [
+ "egor",
+]
+
+[[package]]
 name = "demo_egor_secs_particles"
 version = "0.0.0"
 dependencies = [

--- a/crates/egor_app/src/input.rs
+++ b/crates/egor_app/src/input.rs
@@ -1,23 +1,67 @@
-pub use winit::{event::MouseButton, keyboard::KeyCode};
+pub use winit::{event::MouseButton, event::Touch, event::TouchPhase, keyboard::KeyCode};
 
 use std::collections::HashMap;
 
 use winit::{
     dpi::PhysicalPosition,
-    event::{ElementState, KeyEvent},
+    event::{DeviceId, ElementState, KeyEvent},
     keyboard::PhysicalKey,
 };
 
-#[derive(Default)]
 pub struct Input {
     keyboard: HashMap<KeyCode, (ElementState, ElementState)>, // (current, previous) state
     mouse_buttons: HashMap<MouseButton, (ElementState, ElementState)>,
     mouse_position: (f32, f32),
     mouse_delta: (f32, f32),
     mouse_wheel_delta: f32,
+    touches: HashMap<u64, Touch>,
+    simulate_touch_with_mouse: bool,
+    simulate_mouse_with_touch: bool,
+    /// Tracks which touch id is acting as the primary mouse (for touch→mouse simulation)
+    primary_touch_id: Option<u64>,
+}
+
+impl Default for Input {
+    fn default() -> Self {
+        Self {
+            keyboard: HashMap::default(),
+            mouse_buttons: HashMap::default(),
+            mouse_position: (0.0, 0.0),
+            mouse_delta: (0.0, 0.0),
+            mouse_wheel_delta: 0.0,
+            touches: HashMap::default(),
+            simulate_touch_with_mouse: false,
+            simulate_mouse_with_touch: false,
+            primary_touch_id: None,
+        }
+    }
 }
 
 impl Input {
+    /// Enable or disable simulating touch events from mouse input.
+    /// When enabled, left mouse button presses/moves/releases generate touch events with id 0.
+    /// Useful for testing touch logic on desktop.
+    pub fn set_simulate_touch_with_mouse(&mut self, enabled: bool) {
+        self.simulate_touch_with_mouse = enabled;
+    }
+
+    /// Enable or disable simulating mouse events from touch input.
+    /// When enabled, the first active touch generates mouse position, delta, and left-button events.
+    /// Useful on mobile to make existing mouse-based code work with touch.
+    pub fn set_simulate_mouse_with_touch(&mut self, enabled: bool) {
+        self.simulate_mouse_with_touch = enabled;
+    }
+
+    /// Returns whether touch-from-mouse simulation is enabled
+    pub fn simulate_touch_with_mouse(&self) -> bool {
+        self.simulate_touch_with_mouse
+    }
+
+    /// Returns whether mouse-from-touch simulation is enabled
+    pub fn simulate_mouse_with_touch(&self) -> bool {
+        self.simulate_mouse_with_touch
+    }
+
     /// Update keyboard state from a `winit` KeyEvent
     pub(crate) fn update_key(&mut self, event: KeyEvent) {
         if let PhysicalKey::Code(key_code) = event.physical_key {
@@ -51,6 +95,85 @@ impl Input {
         self.mouse_wheel_delta += delta;
     }
 
+    /// Update touch state from a winit Touch event
+    pub(crate) fn update_touch(&mut self, touch: Touch) {
+        let id = touch.id;
+        let phase = touch.phase;
+        let location = touch.location;
+
+        self.touches.insert(id, touch);
+
+        if self.simulate_mouse_with_touch {
+            match phase {
+                TouchPhase::Started => {
+                    if self.primary_touch_id.is_none() {
+                        self.primary_touch_id = Some(id);
+                        self.update_cursor(location);
+                        self.update_mouse_button(MouseButton::Left, ElementState::Pressed);
+                    }
+                }
+                TouchPhase::Moved => {
+                    if self.primary_touch_id == Some(id) {
+                        self.update_cursor(location);
+                    }
+                }
+                TouchPhase::Ended | TouchPhase::Cancelled => {
+                    if self.primary_touch_id == Some(id) {
+                        self.update_cursor(location);
+                        self.update_mouse_button(MouseButton::Left, ElementState::Released);
+                        self.primary_touch_id = None;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Simulate a touch event from mouse input (called internally when simulation is enabled)
+    pub(crate) fn simulate_touch_from_mouse(&mut self, button: MouseButton, state: ElementState) {
+        if !self.simulate_touch_with_mouse || button != MouseButton::Left {
+            return;
+        }
+        let pos = self.mouse_position;
+        let phase = match state {
+            ElementState::Pressed => TouchPhase::Started,
+            ElementState::Released => TouchPhase::Ended,
+        };
+        // Use id 0 for mouse-simulated touch
+        self.touches.insert(
+            0,
+            Touch {
+                device_id: DeviceId::dummy(),
+                id: 0,
+                phase,
+                location: PhysicalPosition::new(pos.0 as f64, pos.1 as f64),
+                force: None,
+            },
+        );
+    }
+
+    /// Simulate a touch move from mouse cursor movement (called internally when simulation is enabled)
+    pub(crate) fn simulate_touch_move_from_mouse(&mut self) {
+        if !self.simulate_touch_with_mouse {
+            return;
+        }
+        // Only generate a move if the simulated touch is already active
+        if let Some(touch) = self.touches.get(&0)
+            && matches!(touch.phase, TouchPhase::Started | TouchPhase::Moved)
+        {
+            let pos = self.mouse_position;
+            self.touches.insert(
+                0,
+                Touch {
+                    device_id: DeviceId::dummy(),
+                    id: 0,
+                    phase: TouchPhase::Moved,
+                    location: PhysicalPosition::new(pos.0 as f64, pos.1 as f64),
+                    force: None,
+                },
+            );
+        }
+    }
+
     /// Update previous states & clean up released keys/buttons
     pub(crate) fn end_frame(&mut self) {
         for (curr, prev) in self.keyboard.values_mut() {
@@ -68,6 +191,10 @@ impl Input {
 
         self.mouse_delta = (0.0, 0.0);
         self.mouse_wheel_delta = 0.0;
+
+        // Remove ended/cancelled touches
+        self.touches
+            .retain(|_, touch| !matches!(touch.phase, TouchPhase::Ended | TouchPhase::Cancelled));
     }
 
     /// True if the key went from not pressed last frame to pressed this frame
@@ -155,6 +282,26 @@ impl Input {
     /// Mouse wheel delta this frame (positive = scroll up, negative = scroll down)
     pub fn mouse_scroll(&self) -> f32 {
         self.mouse_wheel_delta
+    }
+
+    /// Returns all active touches this frame
+    pub fn touches(&self) -> Vec<Touch> {
+        self.touches.values().copied().collect()
+    }
+
+    /// Get a specific touch by its id, if it exists
+    pub fn touch(&self, id: u64) -> Option<Touch> {
+        self.touches.get(&id).copied()
+    }
+
+    /// Returns true if any touch is active (finger on screen)
+    pub fn is_touched(&self) -> bool {
+        !self.touches.is_empty()
+    }
+
+    /// Returns the number of active touches
+    pub fn touch_count(&self) -> usize {
+        self.touches.len()
     }
 }
 

--- a/crates/egor_app/src/lib.rs
+++ b/crates/egor_app/src/lib.rs
@@ -35,6 +35,8 @@ pub struct AppConfig {
     pub decorations: bool,
     pub min_size: Option<(u32, u32)>,
     pub max_size: Option<(u32, u32)>,
+    pub simulate_touch_with_mouse: bool,
+    pub simulate_mouse_with_touch: bool,
 }
 
 impl Default for AppConfig {
@@ -50,6 +52,8 @@ impl Default for AppConfig {
             decorations: true,
             min_size: None,
             max_size: None,
+            simulate_touch_with_mouse: false,
+            simulate_mouse_with_touch: false,
         }
     }
 }
@@ -195,15 +199,22 @@ impl<R, H: AppHandler<R> + 'static> ApplicationHandler<(R, H)> for AppRunner<R, 
             }
             WindowEvent::KeyboardInput { event, .. } => self.input.update_key(event),
             WindowEvent::MouseInput { button, state, .. } => {
-                self.input.update_mouse_button(button, state)
+                self.input.update_mouse_button(button, state);
+                self.input.simulate_touch_from_mouse(button, state);
             }
-            WindowEvent::CursorMoved { position, .. } => self.input.update_cursor(position),
+            WindowEvent::CursorMoved { position, .. } => {
+                self.input.update_cursor(position);
+                self.input.simulate_touch_move_from_mouse();
+            }
             WindowEvent::MouseWheel { delta, .. } => {
                 let wheel_delta = match delta {
                     MouseScrollDelta::LineDelta(_, y) => y,
                     MouseScrollDelta::PixelDelta(pos) => pos.y as f32 / 100.0,
                 };
                 self.input.update_scroll(wheel_delta);
+            }
+            WindowEvent::Touch(touch) => {
+                self.input.update_touch(touch);
             }
             _ => {}
         }
@@ -226,12 +237,16 @@ impl<R, H: AppHandler<R> + 'static> ApplicationHandler<(R, H)> for AppRunner<R, 
 impl<R, H: AppHandler<R> + 'static> AppRunner<R, H> {
     /// Creates a new runner with the given handler & configuration
     pub fn new(handler: H, config: AppConfig) -> Self {
+        let mut input = Input::default();
+        input.set_simulate_touch_with_mouse(config.simulate_touch_with_mouse);
+        input.set_simulate_mouse_with_touch(config.simulate_mouse_with_touch);
+        
         Self {
             handler: Some(handler),
             resource: None,
             window: None,
             proxy: None,
-            input: Input::default(),
+            input,
             timer: FrameTimer::default(),
             config,
         }

--- a/crates/egor_app/src/lib.rs
+++ b/crates/egor_app/src/lib.rs
@@ -240,7 +240,7 @@ impl<R, H: AppHandler<R> + 'static> AppRunner<R, H> {
         let mut input = Input::default();
         input.set_simulate_touch_with_mouse(config.simulate_touch_with_mouse);
         input.set_simulate_mouse_with_touch(config.simulate_mouse_with_touch);
-        
+
         Self {
             handler: Some(handler),
             resource: None,

--- a/crates/egor_glue/src/app.rs
+++ b/crates/egor_glue/src/app.rs
@@ -198,6 +198,24 @@ impl App {
         self
     }
 
+    /// When enabled, left mouse button presses/moves/releases generate touch events with id 0.
+    /// Useful for testing touch logic on desktop.
+    pub fn simulate_touch_with_mouse(mut self, enabled: bool) -> Self {
+        if let Some(c) = self.config.as_mut() {
+            c.simulate_touch_with_mouse = enabled;
+        }
+        self
+    }
+
+    /// When enabled, the first active touch generates mouse position, delta, and left-button events.
+    /// Useful on mobile to make existing mouse-based code work with touch.
+    pub fn simulate_mouse_with_touch(mut self, enabled: bool) -> Self {
+        if let Some(c) = self.config.as_mut() {
+            c.simulate_mouse_with_touch = enabled;
+        }
+        self
+    }
+
     /// Run the app with a per-frame update closure
     pub fn run(mut self, #[allow(unused_mut)] mut update: impl FnMut(&mut FrameContext) + 'static) {
         #[cfg(all(feature = "hot_reload", not(target_arch = "wasm32")))]

--- a/demos/multi_touch/Cargo.toml
+++ b/demos/multi_touch/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "demo_egor_multi_touch"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+# for android, `x run` expects package name to match generated lib so
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# renamed to avoid conflict with generated lib so
+[[bin]]
+name = "multi_touch"
+path = "src/main.rs"
+
+[dependencies]
+egor = { path = "../../" }

--- a/demos/multi_touch/src/lib.rs
+++ b/demos/multi_touch/src/lib.rs
@@ -1,0 +1,92 @@
+use egor::{
+    app::{App, FrameContext},
+    input::TouchPhase,
+    math::{Vec2, vec2},
+    render::Color,
+};
+use std::collections::HashMap;
+
+const TOUCH_COLORS: &[[f32; 4]] = &[
+    [1.0, 0.3, 0.3, 0.9],
+    [0.3, 1.0, 0.3, 0.9],
+    [0.3, 0.5, 1.0, 0.9],
+    [1.0, 1.0, 0.2, 0.9],
+    [1.0, 0.4, 1.0, 0.9],
+    [0.2, 1.0, 1.0, 0.9],
+    [1.0, 0.6, 0.2, 0.9],
+    [0.7, 0.3, 1.0, 0.9],
+];
+
+egor::main!(main);
+pub fn main() {
+    let mut touch_paths: HashMap<u64, Vec<Vec2>> = HashMap::new();
+
+    App::new()
+        .title("Egor Multi-Touch Demo")
+        .simulate_touch_with_mouse(true)
+        .run(
+            move |FrameContext {
+                      gfx, input, timer, ..
+                  }| {
+                let screen = gfx.screen_size();
+                gfx.camera().center(Vec2::ZERO, screen);
+
+                // Track touch paths
+                for touch in input.touches() {
+                    let world_pos = gfx
+                        .camera()
+                        .screen_to_world(vec2(touch.location.x as f32, touch.location.y as f32));
+                    match touch.phase {
+                        TouchPhase::Started => {
+                            touch_paths.insert(touch.id, vec![world_pos]);
+                        }
+                        TouchPhase::Moved => {
+                            touch_paths.entry(touch.id).or_default().push(world_pos);
+                        }
+                        TouchPhase::Ended | TouchPhase::Cancelled => {
+                            touch_paths.remove(&touch.id);
+                        }
+                    }
+                }
+
+                // Draw touch paths and dots
+                for (idx, (id, path)) in touch_paths.iter().enumerate() {
+                    let c = TOUCH_COLORS[idx % TOUCH_COLORS.len()];
+                    let color = Color::new(c);
+                    let trail_color = Color::new([c[0], c[1], c[2], 0.5]);
+
+                    if path.len() >= 2 {
+                        let mut builder = gfx
+                            .path()
+                            .thickness(3.0)
+                            .stroke_color(trail_color)
+                            .begin(path[0]);
+                        for &pt in &path[1..] {
+                            builder = builder.line_to(pt);
+                        }
+                    }
+
+                    if let Some(&pos) = path.last() {
+                        gfx.polygon().segments(16).at(pos).radius(12.0).color(color);
+                        gfx.polygon()
+                            .segments(16)
+                            .at(pos)
+                            .radius(6.0)
+                            .color(Color::WHITE);
+
+                        let screen_pos = gfx.camera().world_to_screen(pos);
+                        gfx.text(&format!("touch {}", id))
+                            .at(screen_pos + vec2(16.0, -16.0))
+                            .color(color);
+                    }
+                }
+
+                gfx.text(&format!(
+                    "touches: {} | fps: {:.0}",
+                    input.touch_count(),
+                    timer.fps
+                ))
+                .color(Color::WHITE);
+            },
+        );
+}

--- a/demos/multi_touch/src/main.rs
+++ b/demos/multi_touch/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    demo_egor_multi_touch::main();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod app {
 }
 
 pub mod input {
-    pub use egor_app::input::{Input, KeyCode, MouseButton};
+    pub use egor_app::input::{Input, KeyCode, MouseButton, Touch, TouchPhase};
 }
 
 pub mod time {


### PR DESCRIPTION
Added touch input and multi touch support including a new multi_touch demo. 

Screenshot from android:
![Screenshot_20260316_224156](https://github.com/user-attachments/assets/fd31dce5-a887-4de8-a108-7bc5207eafa8)

Also added two flags to support simulating mouse input when touched, and touch input when mouse events happen. This is helpful especially on mobile first games which also have a desktop client to avoid having todo touch and mouse checks.

Fixes #49 and #50 